### PR TITLE
Update Container interface to accept symbols

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5,6 +5,7 @@
   "requires": true,
   "packages": {
     "": {
+      "name": "diddly",
       "version": "0.0.1",
       "license": "MIT",
       "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "diddly",
-  "version": "0.0.1",
+  "version": "0.0.2",
   "description": "Pure functional dependency injection for TypeScript",
   "source": "./src/diddly.ts",
   "exports": "./dist/diddly.modern.js",

--- a/src/__tests__/container.test.ts
+++ b/src/__tests__/container.test.ts
@@ -7,6 +7,13 @@ test('can register a dependency', () => {
   expect(container.resolve('foo')).toBe(5);
 });
 
+test('can register a symbol as the name for a dependency', () => {
+  const name = Symbol.for('foo');
+  const container = createContainer().register(name, () => 5);
+
+  expect(container.resolve(name)).toBe(5);
+});
+
 test('re-registering the same dependency overwrites it', () => {
   const container = createContainer()
     .register('foo', () => 5)

--- a/src/container.ts
+++ b/src/container.ts
@@ -1,4 +1,6 @@
-export interface Container<TDependencies extends Record<string, unknown>> {
+export interface Container<
+  TDependencies extends Record<string | symbol, unknown>
+> {
   /**
    * Resolve a dependency from the container.
    *
@@ -14,7 +16,7 @@ export interface Container<TDependencies extends Record<string, unknown>> {
    * @param name The name of the dependency.
    * @param dependency A dependency factory.
    */
-  readonly register: <TName extends string, TDependency>(
+  readonly register: <TName extends string | symbol, TDependency>(
     name: TName,
     dependency: Factory<TDependency, Container<TDependencies>>
   ) => Container<
@@ -30,7 +32,7 @@ export interface Container<TDependencies extends Record<string, unknown>> {
 
 export type Factory<
   T,
-  TContainer extends Container<Record<string, unknown>>
+  TContainer extends Container<Record<string | symbol, unknown>>
 > = (container: TContainer) => T;
 
 /**


### PR DESCRIPTION
The Container interface has been updated to accept symbols as well as strings for dependency names. This offers more flexibility when registering and resolving dependencies. Relevant tests have been added to ensure support for symbols. Additionally, the package version has been updated to reflect these changes.